### PR TITLE
names without dots, slashes or dashes are treated as "variable"

### DIFF
--- a/lib/template-engine.js
+++ b/lib/template-engine.js
@@ -20,6 +20,7 @@ var TemplateEngine = function (options) {
     this.options = _.defaults(options, {
         debug: false,
         root: __dirname,
+        fileLike: /[\.\/\-]/,   // regex for files (dots, slashes, dashes)
         includes: [ './' ]      // include path list
     });
 
@@ -33,7 +34,7 @@ var TemplateEngine = function (options) {
     }, this);
 
     var tt = '(INCLUDE|PROCESS)',
-        comm = '(?:[^#]+)\\s*', // TODO #2
+        // comm = '(?:[^#]+)\\s*', // TODO #2
         quotes = '(?:["\'])?',
         pathSpec = '([a-zA-Z0-9.\\-\\/,~_@]+)';
 
@@ -60,11 +61,15 @@ TemplateEngine.prototype.resolvePath = function (file) {
     return dir ? (dir + '/' + file) : false;
 };
 
+TemplateEngine.prototype.isLikeFile = function (text) {
+    return this.options.fileLike.test(text);
+};
+
 var processTemplate = tco(function(tree, template, parent) {
     var tt;
 
     while ((tt = tree.re.exec(template)) !== null) {
-        if (!tree.seen[tt[2]]) {
+        if (tree.isLikeFile(tt[2]) && !tree.seen[tt[2]]) {
             var token = {
                 pos: tt.index,
                 token: tt[1],
@@ -100,7 +105,8 @@ TemplateEngine.prototype.parse = function (filename) {
         re: this.re,
         seen: this.seen,
         stash: this.stash,
-        resolvePath: _.bind(this.resolvePath, this)
+        resolvePath: _.bind(this.resolvePath, this),
+        isLikeFile: _.bind(this.isLikeFile, this)
     };
 
     if (!filename) {

--- a/test/02-template-engine.js
+++ b/test/02-template-engine.js
@@ -73,6 +73,28 @@ describe('template-engine', function(){
         });
     });
 
+    describe('isLikeFile()', function() {
+        it('should not treat "some_thing" as filename', function() {
+            te.isLikeFile('some_thing').should.be.eql(false);
+        });
+
+        it('should not treat "OtherThing" as filename', function() {
+            te.isLikeFile('OtherThing').should.be.eql(false);
+        });
+
+        it('should treat "b-button.inc" as filename', function() {
+            te.isLikeFile('b-button.inc').should.be.eql(true);
+        });
+
+        it('should treat "inc/button" as filename', function() {
+            te.isLikeFile('inc/button').should.be.eql(true);
+        });
+
+        it('should treat "blocks/b-button.tt" as filename', function() {
+            te.isLikeFile('blocks/b-button.tt').should.be.eql(true);
+        });
+    });
+
     describe('processTemplate()', function(){
         var template,
             tree;
@@ -89,13 +111,19 @@ describe('template-engine', function(){
                     xxx.tt2;; foo ? bar : qux\
                     %] [%~ INCLUDE     \'xxx.tt2\' %]\
                 [% INCLUDE non-existent.inc -%]\
+                [% BLOCK some_thing %]\
+                    <br/>\
+                [% END %]\
+                [% PROCESS some_thing %]\
+                [% INCLUDE OtherThing %]\
             </div>';
 
             tree = {
                 re: te.re,
                 seen: te.seen,
                 stash: te.stash,
-                resolvePath: _.bind(te.resolvePath, te)
+                resolvePath: _.bind(te.resolvePath, te),
+                isLikeFile: _.bind(te.isLikeFile, te)
             };
 
             processTemplate(tree, template, 'root');


### PR DESCRIPTION
Template might contains something like this

```
[% BLOCK fill_message_content %]
    <br/>
[% END %]
...
[% PROCESS fill_message_content %]
```

so parser unable to resolve filename and dies with error

```
Fatal error: Unable to resolve file path:
promo/promo_message_box.inc @ pos 2087: "PROCESS fill_message_content"
```

this fix solves it. 
