### PR TITLE
fixes for correct handle negate in patterns

### DIFF
--- a/lib/gather-files.js
+++ b/lib/gather-files.js
@@ -51,19 +51,41 @@ module.exports.gatherFiles = function (src, cb, opt) {
         sep  : opt.sep
     };
 
-    _.each(src, function (pattern) {
-        // expand each pattern
-        var expanded = cb(path.join(opt.root, pattern));
+    // prepend each pattern with root
+    src = _.map(src, function (pattern) {
+        var neg = '',
+            localRoot,
+            localPattern;
 
-        _.each(expanded, function (file) {
-            // templates/choose/index.html -> templates-choose-index
-            var name = flattenPath(file, flattenPathOpts);
+        // handle negate
+        if (pattern.charAt(0) === '!') {
+            pattern = pattern.substr(1);
+            neg = '!';
+        }
 
-            files.push({
-                src: file,
-                dst: path.join(opt.dest, name, name + opt.extDst),
-                dir: path.join(opt.dest, name)
-            });
+        if (opt.root === '') {
+            localRoot = '';
+            localPattern = neg + pattern;
+        }
+        else {
+            localRoot = neg + opt.root;
+            localPattern = pattern;
+        }
+
+        return path.join(localRoot, localPattern);
+    });
+
+    // expand each patterns
+    var expanded = cb(src);
+
+    _.each(expanded, function (file) {
+        // templates/choose/index.html -> templates-choose-index
+        var name = flattenPath(file, flattenPathOpts);
+
+        files.push({
+            src: file,
+            dst: path.join(opt.dest, name, name + opt.extDst),
+            dir: path.join(opt.dest, name)
         });
     });
 


### PR DESCRIPTION
There is an incorrect handling of negate symbols in glob patterns (`src`). 

``` js
src: [
    'templates/**/*.html',
    '!templates/web-sites/**/*.html'
]
```

These fixes allows to use negate as mentioned at [Configuring tasks: Globbing patterns](http://gruntjs.com/configuring-tasks#globbing-patterns) regardless of the current value of the `root` option.
