### PR TITLE
support for composite String in src property

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ bemdecl: {
 }
 ```
 
+or composite `String` (delimiter depends on platform: `:` on Unix, `;` on Windows)
+
+```js
+bemdecl: {
+    all: {
+        options: { },
+        src: 'templates/foo/*.html:!templates/foo/bar.html',
+        dest: 'bem/bundles.generated'
+    }
+}
+```
+
 As `Array`
 
 ```js

--- a/lib/gather-files.js
+++ b/lib/gather-files.js
@@ -15,7 +15,7 @@ var path = require('path'),
 var toArray = function (val) {
     // String to Array
     if (_.isString(val)) {
-        val = [ val ];
+        val = val.split(path.delimiter);
     }
     // Object to Array
     if (_.isObject(val) && !_.isArray(val)) {

--- a/test/04-gather-files.js
+++ b/test/04-gather-files.js
@@ -13,6 +13,7 @@ require('mocha');
 
 describe('gather-files toArray()', function() {
     it('should accept empty/undefined String', function() {
+        toArray().should.be.eql([]);
         toArray('').should.be.eql([]);
         toArray(undefined).should.be.eql([]);
         toArray(false).should.be.eql([]);
@@ -30,6 +31,13 @@ describe('gather-files toArray()', function() {
     it('should transform String to Array', function() {
         toArray('foo/bar.html').should.be.eql([
             'foo/bar.html'
+        ]);
+    });
+
+    it('should transform composite String to Array', function() {
+        toArray('foo/bar.html:!qux/baz.html').should.be.eql([
+            'foo/bar.html',
+            '!qux/baz.html'
         ]);
     });
 


### PR DESCRIPTION
This fix allows to use composite `String` in `src` property:

``` js
bemdecl: {
    all: {
        src: 'templates/**/*.html:!templates/web-sites/**/*.html',
        dest: 'bemX',
        options: {
            root: 'path/to/root',
            includes: [ 'includes', 'templates' ],
            cut: 1
        }
    }
}
```

Delimeter depends on platform: `;` on Windows, `:` on Unix.
